### PR TITLE
8.3 XS rebase ipxe-20121005-1.0.8

### DIFF
--- a/SOURCES/0001-XSI-2070-Strip-802.1Q-priority-tags-VID-0-in-etherne.patch
+++ b/SOURCES/0001-XSI-2070-Strip-802.1Q-priority-tags-VID-0-in-etherne.patch
@@ -1,0 +1,160 @@
+From 175eae9a11d485b96d8de79ea85995841443fc84 Mon Sep 17 00:00:00 2001
+From: Stephen Cheng <stephen.cheng@citrix.com>
+Date: Fri, 3 Apr 2026 10:26:14 +0800
+Subject: [PATCH] XSI-2070: Strip 802.1Q priority tags (VID=0) in ethernet and
+ UNDI ISR paths
+
+OVS v2.17.7 on XenServer 8.4 preserves 802.1Q priority-tagged frames
+(VID=0, PCP!=0) on internal virtual switch ports. 802.1Q defines VID=0
+as the "null VID" carrying only priority information; a conformant
+bridge would classify these as untagged and not preserve the tag.
+However, OVS delivers them to VMs.
+
+The PXE 2.1 specification does not mention VLAN tags. 
+It is unspecified whether UNDI should present priority-tagged
+frames as-is or strip them. In practice, PXE NBPs such as the Citrix
+PVS Boot Device Manager assume standard Ethernet framing and fail when
+they encounter EtherType 0x8100 instead of the expected 0x0800.
+
+This change strips VID=0 priority tags in two code paths to make NBPs
+that do not handle priority tags work correctly:
+
+1. eth_pull() in ethernet.c: strips VID=0 from the iobuf used by
+   iPXE's native network stack.
+
+2. UNDI ISR in pxe_undi.c: strips VID=0 from basemem_packet, which
+   is returned directly to the PXE NBP caller.
+
+Frames with VID!=0 (real VLAN tags) are left untouched.
+
+Signed-off-by: Stephen Cheng <stephen.cheng@citrix.com>
+---
+ src/arch/i386/interface/pxe/pxe_undi.c | 30 +++++++++++++++++++++
+ src/net/ethernet.c                     | 36 +++++++++++++++++++++++++-
+ 2 files changed, 65 insertions(+), 1 deletion(-)
+
+diff --git a/src/arch/i386/interface/pxe/pxe_undi.c b/src/arch/i386/interface/pxe/pxe_undi.c
+index b102759f..ce6f4c8d 100644
+--- a/src/arch/i386/interface/pxe/pxe_undi.c
++++ b/src/arch/i386/interface/pxe/pxe_undi.c
+@@ -39,6 +39,7 @@ FILE_LICENCE ( GPL2_OR_LATER );
+ #include <ipxe/udp.h>
+ #include <ipxe/arp.h>
+ #include <ipxe/rarp.h>
++#include <ipxe/vlan.h>
+ #include "pxe.h"
+ 
+ int running_pvs_nbp = 0;
+@@ -882,6 +883,9 @@ static PXENV_EXIT_t pxenv_undi_isr ( struct s_PXENV_UNDI_ISR *undi_isr ) {
+ 	size_t ll_hlen;
+ 	struct net_protocol *net_protocol;
+ 	unsigned int prottype;
++	struct ethhdr *bpe;
++	struct vlan_header *bpv;
++	uint16_t tci;
+ 	int rc;
+ 
+ 	/* Use a different debug colour, since UNDI ISR messages are
+@@ -1006,6 +1010,32 @@ static PXENV_EXIT_t pxenv_undi_isr ( struct s_PXENV_UNDI_ISR *undi_isr ) {
+ 		}
+ 		memcpy ( basemem_packet, iobuf->data, len );
+ 
++		/* Strip 802.1Q priority tag (VID=0) from basemem_packet.
++		 *
++		 * The PXE 2.1 spec does not mention VLAN tags and leaves
++		 * it unspecified whether UNDI should present them as-is
++		 * or strip them. This arguably deviates from a strict
++		 * reading of the spec, but existing NBPs (e.g. PVS BDM)
++		 * assume standard Ethernet framing and fail when they
++		 * encounter priority-tagged frames. OVS on XenServer
++		 * internal networks preserves VID=0 tags, so strip them
++		 * here to make these NBPs work.
++		 */
++		bpe = (struct ethhdr *) basemem_packet;
++		if ( len >= ( ETH_HLEN + sizeof ( struct vlan_header ) ) &&
++				bpe->h_protocol == htons ( ETH_P_8021Q ) ) {
++			bpv = (struct vlan_header *)( basemem_packet + ETH_HLEN );
++			tci = ntohs ( bpv->tci );
++			if ( VLAN_TAG ( tci ) == 0 ) {
++				DBGC ( &pxenv_undi_isr, " STRIP_PRIORITY_TAG PCP=%d", VLAN_PRIORITY ( tci ) );
++				bpe->h_protocol = bpv->net_proto;
++				memmove ( basemem_packet + ETH_HLEN,
++						basemem_packet + ETH_HLEN + sizeof ( struct vlan_header ),
++						len - ETH_HLEN - sizeof ( struct vlan_header ) );
++				len -= sizeof ( struct vlan_header );
++			}
++		}
++
+ 		/* Strip link-layer header */
+ 		ll_protocol = pxe_netdev->ll_protocol;
+ 		if ( ( rc = ll_protocol->pull ( pxe_netdev, iobuf, &ll_dest,
+diff --git a/src/net/ethernet.c b/src/net/ethernet.c
+index 4fd2ab6e..80e2c7c3 100644
+--- a/src/net/ethernet.c
++++ b/src/net/ethernet.c
+@@ -31,6 +31,7 @@ FILE_LICENCE ( GPL2_OR_LATER );
+ #include <ipxe/netdevice.h>
+ #include <ipxe/iobuf.h>
+ #include <ipxe/ethernet.h>
++#include <ipxe/vlan.h>
+ 
+ /** @file
+  *
+@@ -79,6 +80,9 @@ int eth_pull ( struct net_device *netdev __unused, struct io_buffer *iobuf,
+ 	       const void **ll_dest, const void **ll_source,
+ 	       uint16_t *net_proto, unsigned int *flags ) {
+ 	struct ethhdr *ethhdr = iobuf->data;
++	struct vlan_header *vlanhdr;
++	uint16_t tci;
++	uint16_t protocol;
+ 
+ 	/* Sanity check */
+ 	if ( iob_len ( iobuf ) < sizeof ( *ethhdr ) ) {
+@@ -87,13 +91,43 @@ int eth_pull ( struct net_device *netdev __unused, struct io_buffer *iobuf,
+ 		return -EINVAL;
+ 	}
+ 
++	/* Save protocol before stripping header */
++	protocol = ethhdr->h_protocol;
++
+ 	/* Strip off Ethernet header */
+ 	iob_pull ( iobuf, sizeof ( *ethhdr ) );
+ 
++	if ( protocol == htons ( ETH_P_8021Q ) ) {
++		/* Sanity check */
++		if ( iob_len ( iobuf ) < sizeof ( *vlanhdr ) ) {
++			DBG ( "Packet too short (%zd bytes)\n",
++			      iob_len ( iobuf ) );
++			return -EINVAL;
++		}
++		
++		vlanhdr = iobuf->data;
++		tci = ntohs ( vlanhdr->tci );
++		
++		/* Strip priority-only tags (VID=0). 802.1Q defines
++		 * VID=0 as the "null VID" carrying only priority
++		 * information. OVS on XenServer internal networks preserve
++		 * these tags. Strip them so upper layers see standard framing.
++		 */
++		if ( VLAN_TAG ( tci ) == 0 ) {
++			DBG ( "VLAN priority tag stripped: PCP=%d, inner proto=0x%04x\n",
++			      VLAN_PRIORITY ( tci ), ntohs ( vlanhdr->net_proto ) );
++			
++			/* Use inner protocol and strip VLAN header */
++			protocol = vlanhdr->net_proto;
++			iob_pull ( iobuf, sizeof ( *vlanhdr ) );
++		}
++		/* For VID != 0, leave the tag for vlan.c to process */
++	}
++
+ 	/* Fill in required fields */
+ 	*ll_dest = ethhdr->h_dest;
+ 	*ll_source = ethhdr->h_source;
+-	*net_proto = ethhdr->h_protocol;
++	*net_proto = protocol;
+ 	*flags = ( ( is_multicast_ether_addr ( ethhdr->h_dest ) ?
+ 		     LL_MULTICAST : 0 ) |
+ 		   ( is_broadcast_ether_addr ( ethhdr->h_dest ) ?
+-- 
+2.48.1
+

--- a/SPECS/ipxe.spec
+++ b/SPECS/ipxe.spec
@@ -1,6 +1,6 @@
-%global package_speccommit 9b634abd4f9d0fee463e45ace05e21f84c353540
+%global package_speccommit 952a00961d6ece23c11637f8ff0687d9231055c6
 %global usver 20121005
-%global xsver 1.0.7
+%global xsver 1.0.8
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 %global package_srccommit a712dae709a
 
@@ -56,23 +56,24 @@ Patch12: 0002-dhcp-Allow-pseudo-DHCP-servers-to-use-pseudo-identif.patch
 Patch13: 0003-dhcp-Ignore-ProxyDHCPACKs-without-PXE-options.patch
 Patch14: 0004-dhcp-Do-not-skip-ProxyDHCPREQUEST-if-next-server-is-.patch
 Patch15: ipxe-238050dfd46e3c4a87329da1d48b4d8dde5af8a1.patch
-Patch16: serial-console.patch
-Patch17: 0001-CP-46112-Inhibit-gcc-false-positive-warnings.patch
-Patch18: 0001-CP-46112-Fix-if-clause-indentation-issues.patch
-Patch19: 0001-CP-46112-Fix-gcc-warnings-for-unused-variable.patch
-Patch20: 0001-CP-46112-build-uninitialized-variable-issue.patch
-Patch21: 0001-CP-46112-Use-Fall-throgh-explicitly-in-case-statemen.patch
-Patch22: 0001-CP-46112-Fix-gcc-warning-of-return-type.patch
-Patch23: 0001-CP-46112-Not-build-unused-NICs.patch
-Patch24: 0001-iscsi-Add-missing-break-statements.patch
-Patch25: 0001-build-Add-missing-const-qualifiers.patch
-Patch26: 0001-legacy-Fix-building-with-GCC-6.patch
-Patch27: 0001-sis190-Fix-building-with-GCC-6.patch
-Patch28: 0001-skge-Fix-building-with-GCC-6.patch
-Patch29: 0001-build-Avoid-implicit-fallthrough-warnings-on-GCC-7.patch
-Patch30: 0001-mucurses-Fix-erroneous-__nonnull-attribute.patch
-Patch31: 0001-zbin-Fix-compiler-warning-with-GCC-9.patch
-Patch32: 0001-build-Be-explicit-about-fcommon-compiler-directive.patch
+Patch16: 0001-XSI-2070-Strip-802.1Q-priority-tags-VID-0-in-etherne.patch
+Patch17: serial-console.patch
+Patch18: 0001-CP-46112-Inhibit-gcc-false-positive-warnings.patch
+Patch19: 0001-CP-46112-Fix-if-clause-indentation-issues.patch
+Patch20: 0001-CP-46112-Fix-gcc-warnings-for-unused-variable.patch
+Patch21: 0001-CP-46112-build-uninitialized-variable-issue.patch
+Patch22: 0001-CP-46112-Use-Fall-throgh-explicitly-in-case-statemen.patch
+Patch23: 0001-CP-46112-Fix-gcc-warning-of-return-type.patch
+Patch24: 0001-CP-46112-Not-build-unused-NICs.patch
+Patch25: 0001-iscsi-Add-missing-break-statements.patch
+Patch26: 0001-build-Add-missing-const-qualifiers.patch
+Patch27: 0001-legacy-Fix-building-with-GCC-6.patch
+Patch28: 0001-sis190-Fix-building-with-GCC-6.patch
+Patch29: 0001-skge-Fix-building-with-GCC-6.patch
+Patch30: 0001-build-Avoid-implicit-fallthrough-warnings-on-GCC-7.patch
+Patch31: 0001-mucurses-Fix-erroneous-__nonnull-attribute.patch
+Patch32: 0001-zbin-Fix-compiler-warning-with-GCC-9.patch
+Patch33: 0001-build-Be-explicit-about-fcommon-compiler-directive.patch
 BuildArch: noarch
 
 BuildRequires: perl
@@ -107,6 +108,9 @@ install -D -m 0644 src/bin/ipxe.bin %{buildroot}/%{_datadir}/%{name}/ipxe.bin
 %{?_cov_results_package}
 
 %changelog
+* Thu Mar 26 2026 Stephen Cheng <stephen.cheng@citrix.com> - 20121005-1.0.8
+- XSI-2070: Strip 802.1Q priority tags in ethernet and UNDI ISR paths
+
 * Mon Jul 29 2024 Stephen Cheng <stephen.cheng@cloud.com> - 20121005-1.0.7
 - CP-46112: Build compatible with XS9
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3283

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

XS rebase that fixes network boot of VMs with VLAN tagged with 802.1Q priority tag.
This fix was introduced for PVS Boot Device Managers.
The update description specifies it's a BIOS boot fix (I'm failing to know why it's BIOS specific).
It's a small step towards the resolution of a known limitation with PXE boot and tagged VLANs for
NBPs that don't support them.

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

I don't think this update is worth mentioning for XCP-ng, we can discuss it.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

Limitation already documented at https://docs.xcp-ng.org/installation/install-xcp-ng/#requirements.
It still holds since only one specific VLAN tag is handled by this update, the other tags are left untouched.

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

No test about the change itself since it requires to tag the lab VLAN with a 802.1Q priority tag,
which can break PXE boot if this patch isn't applied on the lab hosts.
Manual PXE boot of BIOS VM to install XCP-ng 8.3, but I saw lpxelinux in the boot console instead of ipxe,
should I try again with https://docs.xcp-ng.org/installation/install-xcp-ng/#-ipxe-over-http-install ?
Launched install_xcpng.py script on BIOS and UEFI XCP-ng VM, script hang despite installing XCP-ng successfully.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

The change itself has yet to be tested by tagging a VLAN with 802.1Q tag.
Users can test network booting a BIOS VM.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

install_xcpng.py script.

#### What tests have been or will be added to CI for this change? If none, explain why.

None, this change doesn't fully fix a documented limitation with PXE boot.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
